### PR TITLE
add option to filter by header timestamps rather than ros time

### DIFF
--- a/robotdatapy/data/img_data.py
+++ b/robotdatapy/data/img_data.py
@@ -101,7 +101,7 @@ class ImgData(RobotData):
     @classmethod
     def from_bag(cls, path, topic, camera_info_topic=None, time_range=None, time_range_relative=False,
                  time_tol=.1, causal=False, t0=None, compressed=True, color_space=None,
-                 compressed_rvl=False, stride=1):
+                 compressed_rvl=False, stride=1, ignore_ros_time=False):
         """
         Creates ImgData object from bag file
 
@@ -130,8 +130,12 @@ class ImgData(RobotData):
             time_range = cls.get_absolute_bag_time(path, np.array(time_range)).tolist()
 
         # Convert time_range from seconds to nanoseconds for rosbags
-        start_ns = int(time_range[0] * 1e9) if time_range is not None else None
-        stop_ns = int(time_range[1] * 1e9) if time_range is not None else None
+        if time_range is not None and not ignore_ros_time:
+            start_ns = int(time_range[0] * 1e9)
+            stop_ns = int(time_range[1] * 1e9)
+        else:
+            start_ns = None
+            stop_ns = None
 
         times = []
         img_msgs = []
@@ -148,6 +152,11 @@ class ImgData(RobotData):
                     continue
                 msg = reader.deserialize(rawdata, connection.msgtype)
                 t = msg.header.stamp.sec + msg.header.stamp.nanosec*1e-9
+                if (
+                    ignore_ros_time and time_range is not None 
+                    and (t < time_range[0] or t > time_range[1])
+                ):
+                    continue
 
                 times.append(t)
                 img_msgs.append(msg)

--- a/robotdatapy/data/pointcloud_data.py
+++ b/robotdatapy/data/pointcloud_data.py
@@ -284,7 +284,7 @@ class PointCloudData(RobotData):
 
     @classmethod
     def from_bag(cls, path, topic, causal=False, time_tol=.1, t0=None, time_range=None,
-                 time_range_relative=False):
+                 time_range_relative=False, ignore_ros_time=False):
         """
         Creates PointCloudData object from ROS1/ROS2 bag file
 
@@ -299,6 +299,9 @@ class PointCloudData(RobotData):
                 that should be stored within object
             time_range_relative (bool, optional): If True, time_range is interpreted as relative
                 to the bag start time. Defaults to False.
+            ignore_ros_time (bool, optional): If True, filter by header timestamps rather than
+                bag recording timestamps. Use for datasets where header time and bag recording
+                time differ significantly. Defaults to False.
         """
         if time_range is not None:
             assert time_range[0] < time_range[1], "time_range must be given in incrementing order"
@@ -308,8 +311,12 @@ class PointCloudData(RobotData):
             time_range = cls.get_absolute_bag_time(path, np.array(time_range)).tolist()
 
         # Convert time_range from seconds to nanoseconds for rosbags
-        start_ns = int(time_range[0] * 1e9) if time_range is not None else None
-        stop_ns = int(time_range[1] * 1e9) if time_range is not None else None
+        if time_range is not None and not ignore_ros_time:
+            start_ns = int(time_range[0] * 1e9)
+            stop_ns = int(time_range[1] * 1e9)
+        else:
+            start_ns = None
+            stop_ns = None
 
         times = []
         pcds = []
@@ -325,6 +332,8 @@ class PointCloudData(RobotData):
                 if connection.topic != topic:
                     continue
                 t = msg.header.stamp.sec + msg.header.stamp.nanosec*1e-9
+                if ignore_ros_time and time_range is not None and (t < time_range[0] or t > time_range[1]):
+                    continue
                 times.append(t)
 
                 pcds.append(msg)

--- a/robotdatapy/data/pose_data.py
+++ b/robotdatapy/data/pose_data.py
@@ -206,7 +206,8 @@ class PoseData(RobotData):
         T_premultiply: np.array = None,
         T_postmultiply: np.array = None,
         time_range: list = None,
-        time_range_relative: bool = False
+        time_range_relative: bool = False,
+        ignore_ros_time: bool = False
     ):
         """
         Create a PoseData object from a ROS bag file. Supports msg types PoseStamped and Odometry.
@@ -226,6 +227,9 @@ class PoseData(RobotData):
                 that should be stored within object.
             time_range_relative (bool, optional): If True, time_range is interpreted as relative
                 to the bag start time. Defaults to False.
+            ignore_ros_time (bool, optional): If True, filter by header timestamps rather than
+                bag recording timestamps. Use for datasets where header time and bag recording
+                time differ significantly. Defaults to False.
 
         Returns:
             PoseData: PoseData object
@@ -237,8 +241,12 @@ class PoseData(RobotData):
             time_range = cls.get_absolute_bag_time(path, np.array(time_range)).tolist()
 
         # Convert time_range from seconds to nanoseconds for rosbags
-        start_ns = int(time_range[0] * 1e9) if time_range is not None else None
-        stop_ns = int(time_range[1] * 1e9) if time_range is not None else None
+        if time_range is not None and not ignore_ros_time:
+            start_ns = int(time_range[0] * 1e9)
+            stop_ns = int(time_range[1] * 1e9)
+        else:
+            start_ns = None
+            stop_ns = None
 
         times = []
         positions = []
@@ -254,8 +262,11 @@ class PoseData(RobotData):
                 connections=connections, start=start_ns, stop=stop_ns
             ):
                 msg = reader.deserialize(rawdata, connection.msgtype)
+                t_msg = msg.header.stamp.sec + msg.header.stamp.nanosec*1e-9
+                if ignore_ros_time and time_range is not None and (t_msg < time_range[0] or t_msg > time_range[1]):
+                    continue
                 if t0 is None:
-                    t0 = msg.header.stamp.sec + msg.header.stamp.nanosec*1e-9
+                    t0 = t_msg
                 if type(msg).__name__ == 'geometry_msgs__msg__PoseStamped':
                     pose = msg.pose
                 elif type(msg).__name__ == 'nav_msgs__msg__Odometry':
@@ -947,10 +958,12 @@ class PoseData(RobotData):
                         for transform_msg in msg.transforms:
                             # if has appeared multiple times, check that the parent is the same
                             if transform_msg.child_frame_id in tf_tree:
-                                assert tf_tree[transform_msg.child_frame_id][1] == transform_msg.header.frame_id, \
-                                    f"child frame {transform_msg.child_frame_id} has multiple parents"
-                                assert tf_tree[transform_msg.child_frame_id][0] == tf_type, \
-                                    f"child frame {transform_msg.child_frame_id} has multiple tf types"
+                                if tf_tree[transform_msg.child_frame_id][1] != transform_msg.header.frame_id:
+                                    print(f"WARNING: child frame {transform_msg.child_frame_id} has multiple parents:" 
+                                          f"{tf_tree[transform_msg.child_frame_id][1]} and {transform_msg.header.frame_id}")
+                                if tf_tree[transform_msg.child_frame_id][0] != tf_type:
+                                    print(f"WARNING: child frame {transform_msg.child_frame_id} has multiple tf types:" 
+                                          f"{tf_tree[transform_msg.child_frame_id][0]} and {tf_type}")
                             else:
                                 tf_tree[transform_msg.child_frame_id] = (tf_type, transform_msg.header.frame_id)
         return tf_tree

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name='robotdatapy',
-    version='1.1.7',
+    version='1.1.8',
     description='Python package for interfacing with robot data',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
this is slower, but may be more exact for bags recorded while re-running data or datasets like Kimera-Multi where ros time and header timestamps are not synced